### PR TITLE
Replace Perlin Noise with OpenSimplex Noise

### DIFF
--- a/rwg/util/PerlinNoise.java
+++ b/rwg/util/PerlinNoise.java
@@ -1,631 +1,676 @@
-/*****************************************************************************
- *                        J3D.org Copyright (c) 2000
- *                               Java Source
+/**
+ * Replacement PerlinNoise.java that generates
+ * OpenSimplex Noise instead of Perlin Noise.
  *
- * This source is licensed under the GNU LGPL v2.1
- * Please read http://www.gnu.org/copyleft/lgpl.html for more information
- *
- * This software comes with the standard NO WARRANTY disclaimer for any
- * purpose. Use it at your own risk. If there's a problem you get to fix it.
- *
- ****************************************************************************/
+ * Perlin Noise is an antiquated algorithm that tends to
+ * produce visually-significant directional artifacts.
+ * 
+ * by Kurt Spencer
+ */
+ 
 package rwg.util;
 
-import java.util.Random;
-
 /**
- * Computes Perlin Noise for three dimensions.
- * <p>
- *
- * The result is a continuous function that interpolates a smooth path
- * along a series random points. The function is consitent, so given
- * the same parameters, it will always return the same value. The smoothing
- * function is based on the Improving Noise paper presented at Siggraph 2002.
- * <p>
- * Computing noise for one and two dimensions can make use of the 3D problem
- * space by just setting the un-needed dimensions to a fixed value.
- *
- * @author Justin Couch
- * @version $Revision: 1.4 $
+ * @author Kurt Spencer
+ * @version $Revision: 1.0$
  */
-public class PerlinNoise
-{
-	private Random rand;
+public class PerlinNoise {
+ 
+	private static final double STRETCH_CONSTANT_3D = -1.0 / 6;              //(1/Math.sqrt(3+1)-1)/3;
+	private static final double SQUISH_CONSTANT_3D = 1.0 / 3;                //(Math.sqrt(3+1)-1)/3;
 	
-    // Constants for setting up the Perlin-1 noise functions
-    private final int B = 0x1000;
-    private final int BM = 0xff;
+	private static final double NORM_CONSTANT_3D = 103;
+	
+	private static final long DEFAULT_SEED = 0;
+	
+	private short[] perm;
+	private short[] permGradIndex3D;
+	
+	public PerlinNoise() {
+		this(DEFAULT_SEED);
+	}
+	
+	public PerlinNoise(short[] perm) {
+		this.perm = perm;
+		permGradIndex3D = new short[256];
+		
+		for (int i = 0; i < 256; i++) {
+			//Since 3D has 24 gradients, simple bitmask won't work, so precompute modulo array.
+			permGradIndex3D[i] = (short)((perm[i] % (gradients3D.length / 3)) * 3);
+		}
+	}
+	
+	//Initializes the class using a permutation array generated from a 64-bit seed.
+	//Generates a proper permutation (i.e. doesn't merely perform N successive pair swaps on a base array)
+	//Uses a simple 64-bit LCG.
+	public PerlinNoise(long seed) {
+		perm = new short[256];
+		permGradIndex3D = new short[256];
+		short[] source = new short[256];
+		for (short i = 0; i < 256; i++)
+			source[i] = i;
+		//seed = seed * 6364136223846793005l + 1442695040888963407l;
+		//seed = seed * 6364136223846793005l + 1442695040888963407l;
+		//seed = seed * 6364136223846793005l + 1442695040888963407l;
+		for (int i = 255; i >= 0; i--) {
+			seed = seed * 6364136223846793005l + 1442695040888963407l;
+			int r = (int)((seed + 31) % (i + 1));
+			if (r < 0)
+				r += (i + 1);
+			perm[i] = source[r];
+			permGradIndex3D[i] = (short)((perm[i] % (gradients3D.length / 3)) * 3);
+			source[r] = source[i];
+		}
+	}
+	
+	//Alias for 1D
+	public float noise1(float x) {
+		return (float)noise(x, 0.5, 0.5);
+	}
+	
+	//Alias for 2D
+	public float noise2(float x, float y) {
+		return (float)noise(x, y, 0.5);
+	}
+	
+	//Alias for 3D
+	public float noise3(float x, float y, float z) {
+		return (float)noise(x, y, z);
+	}
+	
+	//Alias for 3D (again)
+	public double improvedNoise(double x, double y, double z)
+	{
+		return noise(x, y, z);
+	}
+	
+	//3D OpenSimplex Noise.
+	public double noise(double x, double y, double z) {
+	
+		//Place input coordinates on honeycomb.
+		double stretchOffset = (x + y + z) * STRETCH_CONSTANT_3D;
+		double xs = x + stretchOffset;
+		double ys = y + stretchOffset;
+		double zs = z + stretchOffset;
+		
+		//Floor to get honeycomb coordinates of rhombohedron (stretched cube) super-cell origin.
+		int xsb = fastFloor(xs);
+		int ysb = fastFloor(ys);
+		int zsb = fastFloor(zs);
+		
+		//Skew out to get actual coordinates of rhombohedron origin. We'll need these later.
+		double squishOffset = (xsb + ysb + zsb) * SQUISH_CONSTANT_3D;
+		double xb = xsb + squishOffset;
+		double yb = ysb + squishOffset;
+		double zb = zsb + squishOffset;
+		
+		//Compute honeycomb coordinates relative to rhombohedral origin.
+		double xins = xs - xsb;
+		double yins = ys - ysb;
+		double zins = zs - zsb;
+		
+		//Sum those together to get a value that determines which region we're in.
+		double inSum = xins + yins + zins;
+ 
+		//Positions relative to origin point.
+		double dx0 = x - xb;
+		double dy0 = y - yb;
+		double dz0 = z - zb;
+		
+		//We'll be defining these inside the next block and using them afterwards.
+		double dx_ext0, dy_ext0, dz_ext0;
+		double dx_ext1, dy_ext1, dz_ext1;
+		int xsv_ext0, ysv_ext0, zsv_ext0;
+		int xsv_ext1, ysv_ext1, zsv_ext1;
+		
+		double value = 0;
+		if (inSum <= 1) { //We're inside the tetrahedron (3-Simplex) at (0,0,0)
+			
+			//Determine which two of (0,0,1), (0,1,0), (1,0,0) are closest.
+			byte aPoint = 0x01;
+			double aScore = xins;
+			byte bPoint = 0x02;
+			double bScore = yins;
+			if (aScore >= bScore && zins > bScore) {
+				bScore = zins;
+				bPoint = 0x04;
+			} else if (aScore < bScore && zins > aScore) {
+				aScore = zins;
+				aPoint = 0x04;
+			}
+			
+			//Now we determine the two lattice points not part of the tetrahedron that may contribute.
+			//This depends on the closest two tetrahedral vertices, including (0,0,0)
+			double wins = 1 - inSum;
+			if (wins > aScore || wins > bScore) { //(0,0,0) is one of the closest two tetrahedral vertices.
+				byte c = (bScore > aScore ? bPoint : aPoint); //Our other closest vertex is the closest out of a and b.
+				
+				if ((c & 0x01) == 0) {
+					xsv_ext0 = xsb - 1;
+					xsv_ext1 = xsb;
+					dx_ext0 = dx0 + 1;
+					dx_ext1 = dx0;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb + 1;
+					dx_ext0 = dx_ext1 = dx0 - 1;
+				}
+ 
+				if ((c & 0x02) == 0) {
+					ysv_ext0 = ysv_ext1 = ysb;
+					dy_ext0 = dy_ext1 = dy0;
+					if ((c & 0x01) == 0) {
+						ysv_ext1 -= 1;
+						dy_ext1 += 1;
+					} else {
+						ysv_ext0 -= 1;
+						dy_ext0 += 1;
+					}
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy_ext1 = dy0 - 1;
+				}
+ 
+				if ((c & 0x04) == 0) {
+					zsv_ext0 = zsb;
+					zsv_ext1 = zsb - 1;
+					dz_ext0 = dz0;
+					dz_ext1 = dz0 + 1;
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb + 1;
+					dz_ext0 = dz_ext1 = dz0 - 1;
+				}
+			} else { //(0,0,0) is not one of the closest two tetrahedral vertices.
+				byte c = (byte)(aPoint | bPoint); //Our two extra vertices are determined by the closest two.
+				
+				if ((c & 0x01) == 0) {
+					xsv_ext0 = xsb;
+					xsv_ext1 = xsb - 1;
+					dx_ext0 = dx0 - 2 * SQUISH_CONSTANT_3D;
+					dx_ext1 = dx0 + 1 - SQUISH_CONSTANT_3D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb + 1;
+					dx_ext0 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+					dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x02) == 0) {
+					ysv_ext0 = ysb;
+					ysv_ext1 = ysb - 1;
+					dy_ext0 = dy0 - 2 * SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 + 1 - SQUISH_CONSTANT_3D;
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x04) == 0) {
+					zsv_ext0 = zsb;
+					zsv_ext1 = zsb - 1;
+					dz_ext0 = dz0 - 2 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 + 1 - SQUISH_CONSTANT_3D;
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb + 1;
+					dz_ext0 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+				}
+			}
+ 
+			//Contribution (0,0,0)
+			double attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0;
+			if (attn0 > 0) {
+				attn0 *= attn0;
+				value += attn0 * attn0 * extrapolate(xsb + 0, ysb + 0, zsb + 0, dx0, dy0, dz0);
+			}
+ 
+			//Contribution (1,0,0)
+			double dx1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+			double dy1 = dy0 - 0 - SQUISH_CONSTANT_3D;
+			double dz1 = dz0 - 0 - SQUISH_CONSTANT_3D;
+			double attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+			if (attn1 > 0) {
+				attn1 *= attn1;
+				value += attn1 * attn1 * extrapolate(xsb + 1, ysb + 0, zsb + 0, dx1, dy1, dz1);
+			}
+ 
+			//Contribution (0,1,0)
+			double dx2 = dx0 - 0 - SQUISH_CONSTANT_3D;
+			double dy2 = dy0 - 1 - SQUISH_CONSTANT_3D;
+			double dz2 = dz1;
+			double attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+			if (attn2 > 0) {
+				attn2 *= attn2;
+				value += attn2 * attn2 * extrapolate(xsb + 0, ysb + 1, zsb + 0, dx2, dy2, dz2);
+			}
+ 
+			//Contribution (0,0,1)
+			double dx3 = dx2;
+			double dy3 = dy1;
+			double dz3 = dz0 - 1 - SQUISH_CONSTANT_3D;
+			double attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+			if (attn3 > 0) {
+				attn3 *= attn3;
+				value += attn3 * attn3 * extrapolate(xsb + 0, ysb + 0, zsb + 1, dx3, dy3, dz3);
+			}
+		} else if (inSum >= 2) { //We're inside the tetrahedron (3-Simplex) at (1,1,1)
+		
+			//Determine which two tetrahedral vertices are the closest, out of (1,1,0), (1,0,1), (0,1,1) but not (1,1,1).
+			byte aPoint = 0x06;
+			double aScore = xins;
+			byte bPoint = 0x05;
+			double bScore = yins;
+			if (aScore <= bScore && zins < bScore) {
+				bScore = zins;
+				bPoint = 0x03;
+			} else if (aScore > bScore && zins < aScore) {
+				aScore = zins;
+				aPoint = 0x03;
+			}
+			
+			//Now we determine the two lattice points not part of the tetrahedron that may contribute.
+			//This depends on the closest two tetrahedral vertices, including (1,1,1)
+			double wins = 3 - inSum;
+			if (wins < aScore || wins < bScore) { //(1,1,1) is one of the closest two tetrahedral vertices.
+				byte c = (bScore < aScore ? bPoint : aPoint); //Our other closest vertex is the closest out of a and b.
+				
+				if ((c & 0x01) != 0) {
+					xsv_ext0 = xsb + 2;
+					xsv_ext1 = xsb + 1;
+					dx_ext0 = dx0 - 2 - 3 * SQUISH_CONSTANT_3D;
+					dx_ext1 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb;
+					dx_ext0 = dx_ext1 = dx0 - 3 * SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x02) != 0) {
+					ysv_ext0 = ysv_ext1 = ysb + 1;
+					dy_ext0 = dy_ext1 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+					if ((c & 0x01) != 0) {
+						ysv_ext1 += 1;
+						dy_ext1 -= 1;
+					} else {
+						ysv_ext0 += 1;
+						dy_ext0 -= 1;
+					}
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb;
+					dy_ext0 = dy_ext1 = dy0 - 3 * SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x04) != 0) {
+					zsv_ext0 = zsb + 1;
+					zsv_ext1 = zsb + 2;
+					dz_ext0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 - 3 * SQUISH_CONSTANT_3D;
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb;
+					dz_ext0 = dz_ext1 = dz0 - 3 * SQUISH_CONSTANT_3D;
+				}
+			} else { //(1,1,1) is not one of the closest two tetrahedral vertices.
+				byte c = (byte)(aPoint & bPoint); //Our two extra vertices are determined by the closest two.
+				
+				if ((c & 0x01) != 0) {
+					xsv_ext0 = xsb + 1;
+					xsv_ext1 = xsb + 2;
+					dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+					dx_ext1 = dx0 - 2 - 2 * SQUISH_CONSTANT_3D;
+				} else {
+					xsv_ext0 = xsv_ext1 = xsb;
+					dx_ext0 = dx0 - SQUISH_CONSTANT_3D;
+					dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x02) != 0) {
+					ysv_ext0 = ysb + 1;
+					ysv_ext1 = ysb + 2;
+					dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 2 - 2 * SQUISH_CONSTANT_3D;
+				} else {
+					ysv_ext0 = ysv_ext1 = ysb;
+					dy_ext0 = dy0 - SQUISH_CONSTANT_3D;
+					dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+				}
+ 
+				if ((c & 0x04) != 0) {
+					zsv_ext0 = zsb + 1;
+					zsv_ext1 = zsb + 2;
+					dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 - 2 * SQUISH_CONSTANT_3D;
+				} else {
+					zsv_ext0 = zsv_ext1 = zsb;
+					dz_ext0 = dz0 - SQUISH_CONSTANT_3D;
+					dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+				}
+			}
+			
+			//Contribution (1,1,0)
+			double dx3 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double dy3 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double dz3 = dz0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+			if (attn3 > 0) {
+				attn3 *= attn3;
+				value += attn3 * attn3 * extrapolate(xsb + 1, ysb + 1, zsb + 0, dx3, dy3, dz3);
+			}
+ 
+			//Contribution (1,0,1)
+			double dx2 = dx3;
+			double dy2 = dy0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double dz2 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+			if (attn2 > 0) {
+				attn2 *= attn2;
+				value += attn2 * attn2 * extrapolate(xsb + 1, ysb + 0, zsb + 1, dx2, dy2, dz2);
+			}
+ 
+			//Contribution (0,1,1)
+			double dx1 = dx0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double dy1 = dy3;
+			double dz1 = dz2;
+			double attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+			if (attn1 > 0) {
+				attn1 *= attn1;
+				value += attn1 * attn1 * extrapolate(xsb + 0, ysb + 1, zsb + 1, dx1, dy1, dz1);
+			}
+ 
+			//Contribution (1,1,1)
+			dx0 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+			dy0 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+			dz0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+			double attn0 = 2 - dx0 * dx0 - dy0 * dy0 - dz0 * dz0;
+			if (attn0 > 0) {
+				attn0 *= attn0;
+				value += attn0 * attn0 * extrapolate(xsb + 1, ysb + 1, zsb + 1, dx0, dy0, dz0);
+			}
+		} else { //We're inside the octahedron (Rectified 3-Simplex) in between.
+			double aScore;
+			byte aPoint;
+			boolean aIsFurtherSide;
+			double bScore;
+			byte bPoint;
+			boolean bIsFurtherSide;
+ 
+			//Decide between point (0,0,1) and (1,1,0) as closest
+			double p1 = xins + yins;
+			if (p1 > 1) {
+				aScore = p1 - 1;
+				aPoint = 0x03;
+				aIsFurtherSide = true;
+			} else {
+				aScore = 1 - p1;
+				aPoint = 0x04;
+				aIsFurtherSide = false;
+			}
+ 
+			//Decide between point (0,1,0) and (1,0,1) as closest
+			double p2 = xins + zins;
+			if (p2 > 1) {
+				bScore = p2 - 1;
+				bPoint = 0x05;
+				bIsFurtherSide = true;
+			} else {
+				bScore = 1 - p2;
+				bPoint = 0x02;
+				bIsFurtherSide = false;
+			}
+			
+			//The closest out of the two (1,0,0) and (0,1,1) will replace the furthest out of the two decided above, if closer.
+			double p3 = yins + zins;
+			if (p3 > 1) {
+				double score = p3 - 1;
+				if (aScore <= bScore && aScore < score) {
+					aScore = score;
+					aPoint = 0x06;
+					aIsFurtherSide = true;
+				} else if (aScore > bScore && bScore < score) {
+					bScore = score;
+					bPoint = 0x06;
+					bIsFurtherSide = true;
+				}
+			} else {
+				double score = 1 - p3;
+				if (aScore <= bScore && aScore < score) {
+					aScore = score;
+					aPoint = 0x01;
+					aIsFurtherSide = false;
+				} else if (aScore > bScore && bScore < score) {
+					bScore = score;
+					bPoint = 0x01;
+					bIsFurtherSide = false;
+				}
+			}
+			
+			//Where each of the two closest points are determines how the extra two vertices are calculated.
+			if (aIsFurtherSide == bIsFurtherSide) {
+				if (aIsFurtherSide) { //Both closest points on (1,1,1) side
+ 
+					//One of the two extra points is (1,1,1)
+					dx_ext0 = dx0 - 1 - 3 * SQUISH_CONSTANT_3D;
+					dy_ext0 = dy0 - 1 - 3 * SQUISH_CONSTANT_3D;
+					dz_ext0 = dz0 - 1 - 3 * SQUISH_CONSTANT_3D;
+					xsv_ext0 = xsb + 1;
+					ysv_ext0 = ysb + 1;
+					zsv_ext0 = zsb + 1;
+ 
+					//Other extra point is based on the shared axis.
+					byte c = (byte)(aPoint & bPoint);
+					if ((c & 0x01) != 0) {
+						dx_ext1 = dx0 - 2 - 2 * SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb + 2;
+						ysv_ext1 = ysb;
+						zsv_ext1 = zsb;
+					} else if ((c & 0x02) != 0) {
+						dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 - 2 - 2 * SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb;
+						ysv_ext1 = ysb + 2;
+						zsv_ext1 = zsb;
+					} else {
+						dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 - 2 - 2 * SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb;
+						ysv_ext1 = ysb;
+						zsv_ext1 = zsb + 2;
+					}
+				} else {//Both closest points on (0,0,0) side
+ 
+					//One of the two extra points is (0,0,0)
+					dx_ext0 = dx0;
+					dy_ext0 = dy0;
+					dz_ext0 = dz0;
+					xsv_ext0 = xsb;
+					ysv_ext0 = ysb;
+					zsv_ext0 = zsb;
+ 
+					//Other extra point is based on the omitted axis.
+					byte c = (byte)(aPoint | bPoint);
+					if ((c & 0x01) == 0) {
+						dx_ext1 = dx0 + 1 - SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb - 1;
+						ysv_ext1 = ysb + 1;
+						zsv_ext1 = zsb + 1;
+					} else if ((c & 0x02) == 0) {
+						dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 + 1 - SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 - 1 - SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb + 1;
+						ysv_ext1 = ysb - 1;
+						zsv_ext1 = zsb + 1;
+					} else {
+						dx_ext1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+						dy_ext1 = dy0 - 1 - SQUISH_CONSTANT_3D;
+						dz_ext1 = dz0 + 1 - SQUISH_CONSTANT_3D;
+						xsv_ext1 = xsb + 1;
+						ysv_ext1 = ysb + 1;
+						zsv_ext1 = zsb - 1;
+					}
+				}
+			} else { //One point on (0,0,0) side, one point on (1,1,1) side
+				byte c1, c2;
+				if (aIsFurtherSide) {
+					c1 = aPoint;
+					c2 = bPoint;
+				} else {
+					c1 = bPoint;
+					c2 = aPoint;
+				}
+ 
+				//One contribution is a permutation of (1,1,-1)
+				if ((c1 & 0x01) == 0) {
+					dx_ext0 = dx0 + 1 - SQUISH_CONSTANT_3D;
+					dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+					dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+					xsv_ext0 = xsb - 1;
+					ysv_ext0 = ysb + 1;
+					zsv_ext0 = zsb + 1;
+				} else if ((c1 & 0x02) == 0) {
+					dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+					dy_ext0 = dy0 + 1 - SQUISH_CONSTANT_3D;
+					dz_ext0 = dz0 - 1 - SQUISH_CONSTANT_3D;
+					xsv_ext0 = xsb + 1;
+					ysv_ext0 = ysb - 1;
+					zsv_ext0 = zsb + 1;
+				} else {
+					dx_ext0 = dx0 - 1 - SQUISH_CONSTANT_3D;
+					dy_ext0 = dy0 - 1 - SQUISH_CONSTANT_3D;
+					dz_ext0 = dz0 + 1 - SQUISH_CONSTANT_3D;
+					xsv_ext0 = xsb + 1;
+					ysv_ext0 = ysb + 1;
+					zsv_ext0 = zsb - 1;
+				}
+ 
+				//One contribution is a permutation of (0,0,2)
+				dx_ext1 = dx0 - 2 * SQUISH_CONSTANT_3D;
+				dy_ext1 = dy0 - 2 * SQUISH_CONSTANT_3D;
+				dz_ext1 = dz0 - 2 * SQUISH_CONSTANT_3D;
+				xsv_ext1 = xsb;
+				ysv_ext1 = ysb;
+				zsv_ext1 = zsb;
+				if ((c2 & 0x01) != 0) {
+					dx_ext1 -= 2;
+					xsv_ext1 += 2;
+				} else if ((c2 & 0x02) != 0) {
+					dy_ext1 -= 2;
+					ysv_ext1 += 2;
+				} else {
+					dz_ext1 -= 2;
+					zsv_ext1 += 2;
+				}
+			}
+ 
+			//Contribution (1,0,0)
+			double dx1 = dx0 - 1 - SQUISH_CONSTANT_3D;
+			double dy1 = dy0 - 0 - SQUISH_CONSTANT_3D;
+			double dz1 = dz0 - 0 - SQUISH_CONSTANT_3D;
+			double attn1 = 2 - dx1 * dx1 - dy1 * dy1 - dz1 * dz1;
+			if (attn1 > 0) {
+				attn1 *= attn1;
+				value += attn1 * attn1 * extrapolate(xsb + 1, ysb + 0, zsb + 0, dx1, dy1, dz1);
+			}
+ 
+			//Contribution (0,1,0)
+			double dx2 = dx0 - 0 - SQUISH_CONSTANT_3D;
+			double dy2 = dy0 - 1 - SQUISH_CONSTANT_3D;
+			double dz2 = dz1;
+			double attn2 = 2 - dx2 * dx2 - dy2 * dy2 - dz2 * dz2;
+			if (attn2 > 0) {
+				attn2 *= attn2;
+				value += attn2 * attn2 * extrapolate(xsb + 0, ysb + 1, zsb + 0, dx2, dy2, dz2);
+			}
+ 
+			//Contribution (0,0,1)
+			double dx3 = dx2;
+			double dy3 = dy1;
+			double dz3 = dz0 - 1 - SQUISH_CONSTANT_3D;
+			double attn3 = 2 - dx3 * dx3 - dy3 * dy3 - dz3 * dz3;
+			if (attn3 > 0) {
+				attn3 *= attn3;
+				value += attn3 * attn3 * extrapolate(xsb + 0, ysb + 0, zsb + 1, dx3, dy3, dz3);
+			}
+ 
+			//Contribution (1,1,0)
+			double dx4 = dx0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double dy4 = dy0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double dz4 = dz0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double attn4 = 2 - dx4 * dx4 - dy4 * dy4 - dz4 * dz4;
+			if (attn4 > 0) {
+				attn4 *= attn4;
+				value += attn4 * attn4 * extrapolate(xsb + 1, ysb + 1, zsb + 0, dx4, dy4, dz4);
+			}
+ 
+			//Contribution (1,0,1)
+			double dx5 = dx4;
+			double dy5 = dy0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double dz5 = dz0 - 1 - 2 * SQUISH_CONSTANT_3D;
+			double attn5 = 2 - dx5 * dx5 - dy5 * dy5 - dz5 * dz5;
+			if (attn5 > 0) {
+				attn5 *= attn5;
+				value += attn5 * attn5 * extrapolate(xsb + 1, ysb + 0, zsb + 1, dx5, dy5, dz5);
+			}
+ 
+			//Contribution (0,1,1)
+			double dx6 = dx0 - 0 - 2 * SQUISH_CONSTANT_3D;
+			double dy6 = dy4;
+			double dz6 = dz5;
+			double attn6 = 2 - dx6 * dx6 - dy6 * dy6 - dz6 * dz6;
+			if (attn6 > 0) {
+				attn6 *= attn6;
+				value += attn6 * attn6 * extrapolate(xsb + 0, ysb + 1, zsb + 1, dx6, dy6, dz6);
+			}
+		}
+ 
+		//First extra vertex
+		double attn_ext0 = 2 - dx_ext0 * dx_ext0 - dy_ext0 * dy_ext0 - dz_ext0 * dz_ext0;
+		if (attn_ext0 > 0)
+		{
+			attn_ext0 *= attn_ext0;
+			value += attn_ext0 * attn_ext0 * extrapolate(xsv_ext0, ysv_ext0, zsv_ext0, dx_ext0, dy_ext0, dz_ext0);
+		}
+ 
+		//Second extra vertex
+		double attn_ext1 = 2 - dx_ext1 * dx_ext1 - dy_ext1 * dy_ext1 - dz_ext1 * dz_ext1;
+		if (attn_ext1 > 0)
+		{
+			attn_ext1 *= attn_ext1;
+			value += attn_ext1 * attn_ext1 * extrapolate(xsv_ext1, ysv_ext1, zsv_ext1, dx_ext1, dy_ext1, dz_ext1);
+		}
+		
+		return value / NORM_CONSTANT_3D;
+	}
+	
+	private double extrapolate(int xsb, int ysb, int zsb, double dx, double dy, double dz)
+	{
+		int index = permGradIndex3D[(perm[(perm[xsb & 0xFF] + ysb) & 0xFF] + zsb) & 0xFF];
+		return gradients3D[index] * dx
+			+ gradients3D[index + 1] * dy
+			+ gradients3D[index + 2] * dz;
+	}
+	
+	private static int fastFloor(double x) {
+		int xi = (int)x;
+		return x < xi ? xi - 1 : xi;
+	}
+	
+	//Gradients for 3D. They approximate the directions to the
+	//vertices of a rhombicuboctahedron from the center, skewed so
+	//that the triangular and square facets can be inscribed inside
+	//circles of the same radius.
+	private static byte[] gradients3D = new byte[] {
+		-11,  4,  4,     -4,  11,  4,    -4,  4,  11,
+		 11,  4,  4,      4,  11,  4,     4,  4,  11,
+		-11, -4,  4,     -4, -11,  4,    -4, -4,  11,
+		 11, -4,  4,      4, -11,  4,     4, -4,  11,
+		-11,  4, -4,     -4,  11, -4,    -4,  4, -11,
+		 11,  4, -4,      4,  11, -4,     4,  4, -11,
+		-11, -4, -4,     -4, -11, -4,    -4, -4, -11,
+		 11, -4, -4,      4, -11, -4,     4, -4, -11,
+	};
 
-    private final int N = 0x1000;
-    private final int NP = 12;   /* 2^N */
-    private final int NM = 0xfff;
-
-    /** Default sample size to work with */
-    private final int DEFAULT_SAMPLE_SIZE = 256;
-
-    /** The log of 1/2 constant. Used Everywhere */
-    private final float LOG_HALF = (float)Math.log(0.5);
-
-    /** Permutation array for the improved noise function */
-    private int[] p_imp;
-
-    /** P array for perline 1 noise */
-    private int[] p;
-    private float[][] g3;
-    private float[][] g2;
-    private float[] g1;
-
-
-    /**
-     * Create a new noise creator with the default seed value
-     */
-    public PerlinNoise()
-    {
-        this(100);
-    }
-
-    /**
-     * Create a new noise creator with the given seed value for the randomness
-     *
-     * @param seed The seed value to use
-     */
-    public PerlinNoise(long seed)
-    {
-        p_imp = new int[DEFAULT_SAMPLE_SIZE << 1];
-
-        int i, j, k;
-        rand = new Random(seed);
-
-        // Calculate the table of psuedo-random coefficients.
-        for(i = 0; i < DEFAULT_SAMPLE_SIZE; i++)
-            p_imp[i] = i;
-
-        // generate the psuedo-random permutation table.
-        while(--i > 0)
-        {
-            k = p_imp[i];
-            j = (int)(rand.nextLong() & DEFAULT_SAMPLE_SIZE);
-            p_imp[i] = p_imp[j];
-            p_imp[j] = k;
-        }
-
-        initPerlin1();
-    }
-
-    /**
-     * Computes noise function for three dimensions at the point (x,y,z).
-     *
-     * @param x x dimension parameter
-     * @param y y dimension parameter
-     * @param z z dimension parameter
-     * @return the noise value at the point (x, y, z)
-     */
-    public double improvedNoise(double x, double y, double z)
-    {
-        // Constraint the point to a unit cube
-        int uc_x = (int)Math.floor(x) & 255;
-        int uc_y = (int)Math.floor(y) & 255;
-        int uc_z = (int)Math.floor(z) & 255;
-
-        // Relative location of the point in the unit cube
-        double xo = x - Math.floor(x);
-        double yo = y - Math.floor(y);
-        double zo = z - Math.floor(z);
-
-        // Fade curves for x, y and z
-        double u = fade(xo);
-        double v = fade(yo);
-        double w = fade(zo);
-
-        // Generate a hash for each coordinate to find out where in the cube
-        // it lies.
-        int a =  p_imp[uc_x] + uc_y;
-        int aa = p_imp[a] + uc_z;
-        int ab = p_imp[a + 1] + uc_z;
-
-        int b =  p_imp[uc_x + 1] + uc_y;
-        int ba = p_imp[b] + uc_z;
-        int bb = p_imp[b + 1] + uc_z;
-
-        // blend results from the 8 corners based on the noise function
-        double c1 = grad(p_imp[aa], xo, yo, zo);
-        double c2 = grad(p_imp[ba], xo - 1, yo, zo);
-        double c3 = grad(p_imp[ab], xo, yo - 1, zo);
-        double c4 = grad(p_imp[bb], xo - 1, yo - 1, zo);
-        double c5 = grad(p_imp[aa + 1], xo, yo, zo - 1);
-        double c6 = grad(p_imp[ba + 1], xo - 1, yo, zo - 1);
-        double c7 = grad(p_imp[ab + 1], xo, yo - 1, zo - 1);
-        double c8 = grad(p_imp[bb + 1], xo - 1, yo - 1, zo - 1);
-
-        return lerp(w, lerp(v, lerp(u, c1, c2), lerp(u, c3, c4)),
-                       lerp(v, lerp(u, c5, c6), lerp(u, c7, c8)));
-    }
-
-    /**
-     * 1-D noise generation function using the original perlin algorithm.
-     *
-     * @param x Seed for the noise function
-     * @return The noisy output
-     */
-    public float noise1(float x)
-    {
-        float t = x + N;
-        int bx0 = ((int) t) & BM;
-        int bx1 = (bx0 + 1) & BM;
-        float rx0 = t - (int) t;
-        float rx1 = rx0 - 1;
-
-        float sx = sCurve(rx0);
-
-        float u = rx0 * g1[p[bx0]];
-        float v = rx1 * g1[p[bx1]];
-
-        return lerp(sx, u, v);
-    }
-
-    /**
-     * Create noise in a 2D space using the orignal perlin noise algorithm.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @return A noisy value at the given position
-     */
-    public float noise2(float x, float y)
-    {
-        float t = x + N;
-        int bx0 = ((int)t) & BM;
-        int bx1 = (bx0 + 1) & BM;
-        float rx0 = t - (int)t;
-        float rx1 = rx0 - 1;
-
-        t = y + N;
-        int by0 = ((int)t) & BM;
-        int by1 = (by0 + 1) & BM;
-        float ry0 = t - (int)t;
-        float ry1 = ry0 - 1;
-
-        int i = p[bx0];
-        int j = p[bx1];
-
-        int b00 = p[i + by0];
-        int b10 = p[j + by0];
-        int b01 = p[i + by1];
-        int b11 = p[j + by1];
-
-        float sx = sCurve(rx0);
-        float sy = sCurve(ry0);
-
-        float[] q = g2[b00];
-        float u = rx0 * q[0] + ry0 * q[1];
-        q = g2[b10];
-        float v = rx1 * q[0] + ry0 * q[1];
-        float a = lerp(sx, u, v);
-
-        q = g2[b01];
-        u = rx0 * q[0] + ry1 * q[1];
-        q = g2[b11];
-        v = rx1 * q[0] + ry1 * q[1];
-        float b = lerp(sx, u, v);
-
-        return lerp(sy, a, b);
-    }
-
-    /**
-     * Create noise in a 3D space using the orignal perlin noise algorithm.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @param z The Z coordinate of the location to sample
-     * @return A noisy value at the given position
-     */
-    public float noise3(float x, float y, float z)
-    {
-    	float t = x + (float)N;
-        int bx0 = ((int)t) & BM;
-        int bx1 = (bx0 + 1) & BM;
-        float rx0 = (float)(t - (int)t);
-        float rx1 = rx0 - 1;
-
-        t = y + (float)N;
-        int by0 = ((int)t) & BM;
-        int by1 = (by0 + 1) & BM;
-        float ry0 = (float)(t - (int)t);
-        float ry1 = ry0 - 1;
-
-        t = z + (float)N;
-        int bz0 = ((int)t) & BM;
-        int bz1 = (bz0 + 1) & BM;
-        float rz0 = (float)(t - (int)t);
-        float rz1 = rz0 - 1;
-
-        int i = p[bx0];
-        int j = p[bx1];
-
-        int b00 = p[i + by0];
-        int b10 = p[j + by0];
-        int b01 = p[i + by1];
-        int b11 = p[j + by1];
-
-        t  = sCurve(rx0);
-        float sy = sCurve(ry0);
-        float sz = sCurve(rz0);
-
-        float[] q = g3[b00 + bz0];
-        float u = (rx0 * q[0] + ry0 * q[1] + rz0 * q[2]);
-        q = g3[b10 + bz0];
-        float v = (rx1 * q[0] + ry0 * q[1] + rz0 * q[2]);
-        float a = lerp(t, u, v);
-
-        q = g3[b01 + bz0];
-        u = (rx0 * q[0] + ry1 * q[1] + rz0 * q[2]);
-        q = g3[b11 + bz0];
-        v = (rx1 * q[0] + ry1 * q[1] + rz0 * q[2]);
-        float b = lerp(t, u, v);
-
-        float c = lerp(sy, a, b);
-
-        q = g3[b00 + bz1];
-        u = (rx0 * q[0] + ry0 * q[1] + rz1 * q[2]);
-        q = g3[b10 + bz1];
-        v = (rx1 * q[0] + ry0 * q[1] + rz1 * q[2]);
-        a = lerp(t, u, v);
-
-        q = g3[b01 + bz1];
-        u = (rx0 * q[0] + ry1 * q[1] + rz1 * q[2]);
-        q = g3[b11 + bz1];
-        v = (rx1 * q[0] + ry1 * q[1] + rz1 * q[2]);
-        b = lerp(t, u, v);
-
-        float d = lerp(sy, a, b);
-
-        return lerp(sz, c, d);
-    }
-
-    /**
-     * Create a turbulent noise output based on the core noise function. This
-     * uses the noise as a base function and is suitable for creating clouds,
-     * marble and explosion effects. For example, a typical marble effect would
-     * set the colour to be:
-     * <pre>
-     *    sin(point + turbulence(point) * point.x);
-     * </pre>
-     */
-    public double imporvedTurbulence(double x,
-                                     double y,
-                                     double z,
-                                     float loF,
-                                     float hiF)
-    {
-        double p_x = x + 123.456f;
-        double p_y = y;
-        double p_z = z;
-        double t = 0;
-        double f;
-
-        for(f = loF; f < hiF; f *= 2)
-        {
-            t += Math.abs(improvedNoise(p_x, p_y, p_z)) / f;
-
-            p_x *= 2;
-            p_y *= 2;
-            p_z *= 2;
-        }
-
-        return t - 0.3;
-    }
-
-    /**
-     * Create a turbulance function in 2D using the original perlin noise
-     * function.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @param freq The frequency of the turbluance to create
-     * @return The value at the given coordinates
-     */
-    public float turbulence2(float x, float y, float freq)
-    {
-        float t = 0;
-
-        do
-        {
-            t += noise2(freq * x, freq * y) / freq;
-            freq *= 0.5f;
-        }
-        while (freq >= 1);
-
-        return t;
-    }
-
-    /**
-     * Create a turbulance function in 3D using the original perlin noise
-     * function.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @param z The Z coordinate of the location to sample
-     * @param freq The frequency of the turbluance to create
-     * @return The value at the given coordinates
-     */
-    public float turbulence3(float x, float y, float z, float freq)
-    {
-        float t = 0;
-
-        do
-        {
-            t += noise3(freq * x, freq * y, freq * z) / freq;
-            freq *= 0.5f;
-        }
-        while (freq >= 1);
-
-        return t;
-    }
-
-    /**
-     * Create a 1D tileable noise function for the given width.
-     *
-     * @param x The X coordinate to generate the noise for
-     * @param w The width of the tiled block
-     * @return The value of the noise at the given coordinate
-     */
-    public float tileableNoise1(float x, float w)
-    {
-        return (noise1(x)     * (w - x) +
-                noise1(x - w) *      x) / w;
-    }
-
-    /**
-     * Create a 2D tileable noise function for the given width and height.
-     *
-     * @param x The X coordinate to generate the noise for
-     * @param y The Y coordinate to generate the noise for
-     * @param w The width of the tiled block
-     * @param h The height of the tiled block
-     * @return The value of the noise at the given coordinate
-     */
-    public float tileableNoise2(float x, float y, float w, float h)
-    {
-        return (noise2(x,     y)     * (w - x) * (h - y) +
-                noise2(x - w, y)     *      x  * (h - y) +
-                noise2(x,     y - h) * (w - x) *      y  +
-                noise2(x - w, y - h) *      x  *      y) / (w * h);
-    }
-
-    /**
-     * Create a 3D tileable noise function for the given width, height and
-     * depth.
-     *
-     * @param x The X coordinate to generate the noise for
-     * @param y The Y coordinate to generate the noise for
-     * @param z The Z coordinate to generate the noise for
-     * @param w The width of the tiled block
-     * @param h The height of the tiled block
-     * @param d The depth of the tiled block
-     * @return The value of the noise at the given coordinate
-     */
-    public float tileableNoise3(float x,
-                                float y,
-                                float z,
-                                float w,
-                                float h,
-                                float d)
-    {
-        return (noise3(x,     y,     z)     * (w - x) * (h - y) * (d - z) +
-                noise3(x - w, y,     z)     *      x  * (h - y) * (d - z) +
-                noise3(x,     y - h, z)     * (w - x) *      y  * (d - z) +
-                noise3(x - w, y - h, z)     *      x  *      y  * (d - z) +
-                noise3(x,     y,     z - d) * (w - x) * (h - y) *      z  +
-                noise3(x - w, y,     z - d) *      x  * (h - y) *      z  +
-                noise3(x,     y - h, z - d) * (w - x) *      y  *      z  +
-                noise3(x - w, y - h, z - d) *      x  *      y  *      z) /
-                (w * h * d);
-    }
-
-    /**
-     * Create a turbulance function that can be tiled across a surface in 2D.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @param w The width to tile over
-     * @param h The height to tile over
-     * @param freq The frequency of the turbluance to create
-     * @return The value at the given coordinates
-     */
-    public float tileableTurbulence2(float x,
-                                     float y,
-                                     float w,
-                                     float h,
-                                     float freq)
-    {
-        float t = 0;
-
-        do
-        {
-            t += tileableNoise2(freq * x, freq * y, w * freq, h * freq) / freq;
-            freq *= 0.5f;
-        }
-        while (freq >= 1);
-
-        return t;
-    }
-
-    /**
-     * Create a turbulance function that can be tiled across a surface in 3D.
-     *
-     * @param x The X coordinate of the location to sample
-     * @param y The Y coordinate of the location to sample
-     * @param z The Z coordinate of the location to sample
-     * @param w The width to tile over
-     * @param h The height to tile over
-     * @param d The depth to tile over
-     * @param freq The frequency of the turbluance to create
-     * @return The value at the given coordinates
-     */
-    public float tileableTurbulence3(float x,
-                                     float y,
-                                     float z,
-                                     float w,
-                                     float h,
-                                     float d,
-                                     float freq)
-    {
-        float t = 0;
-
-        do
-        {
-            t += tileableNoise3(freq * x,
-                                freq * y,
-                                freq * z,
-                                w * freq,
-                                h * freq,
-                                d * freq) / freq;
-            freq *= 0.5f;
-        }
-        while (freq >= 1);
-
-        return t;
-    }
-
-
-    /**
-     * Simple lerp function using doubles.
-     */
-    private double lerp(double t, double a, double b)
-    {
-        return a + t * (b - a);
-    }
-
-    /**
-     * Simple lerp function using floats.
-     */
-    private float lerp(float t, float a, float b)
-    {
-        return a + t * (b - a);
-    }
-
-    /**
-     * Fade curve calculation which is 6t^5 - 15t^4 + 10t^3. This is the new
-     * algorithm, where the old one used to be 3t^2 - 2t^3.
-     *
-     * @param t The t parameter to calculate the fade for
-     * @return the drop-off amount.
-     */
-    private double fade(double t)
-    {
-        return t * t * t * (t * (t * 6 - 15) + 10);
-    }
-
-    /**
-     * Calculate the gradient function based on the hash code.
-     */
-    private double grad(int hash, double x, double y, double z)
-    {
-        // Convert low 4 bits of hash code into 12 gradient directions.
-        int h = hash & 15;
-        double u = (h < 8 || h == 12 || h == 13) ? x : y;
-        double v = (h < 4 || h == 12 || h == 13) ? y : z;
-
-        return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
-    }
-
-    /**
-     * Simple bias generator using exponents.
-     */
-    private float bias(float a, float b)
-    {
-        return (float)Math.pow(a, Math.log(b) / LOG_HALF);
-    }
-
-
-    /*
-     * Gain generator that caps to the range of [0, 1].
-     */
-    private float gain(float a, float b)
-    {
-        if(a < 0.001f)
-            return 0;
-        else if (a > 0.999f)
-            return 1.0f;
-
-        double p = Math.log(1.0f - b) / LOG_HALF;
-
-        if(a < 0.5f)
-            return (float)(Math.pow(2 * a, p) / 2);
-        else
-            return 1 - (float)(Math.pow(2 * (1.0f - a), p) / 2);
-    }
-
-    /**
-     * S-curve function for value distribution for Perlin-1 noise function.
-     */
-    private float sCurve(float t)
-    {
-        return (t * t * (3 - 2 * t));
-    }
-
-    /**
-     * 2D-vector normalisation function.
-     */
-    private void normalize2(float[] v)
-    {
-        float s = (float)(1 / Math.sqrt(v[0] * v[0] + v[1] * v[1]));
-        v[0] *= s;
-        v[1] *= s;
-    }
-
-    /**
-     * 3D-vector normalisation function.
-     */
-    private void normalize3(float[] v)
-    {
-        float s = (float)(1 / Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]));
-        v[0] *= s;
-        v[1] *= s;
-        v[2] *= s;
-    }
-
-    /**
-     * Initialise the lookup arrays used by Perlin 1 function.
-     */
-    private void initPerlin1()
-    {
-        p = new int[B + B + 2];
-        g3 = new float[B + B + 2][3];
-        g2 = new float[B + B + 2][2];
-        g1 = new float[B + B + 2];
-        int i, j, k;
-
-        for(i = 0; i < B; i++)
-        {
-            p[i] = i;
-
-            g1[i] = (float)(((rand.nextDouble() * Integer.MAX_VALUE) % (B + B)) - B) / B;
-
-            for(j = 0; j < 2; j++)
-                g2[i][j] = (float)(((rand.nextDouble() * Integer.MAX_VALUE) % (B + B)) - B) / B;
-            normalize2(g2[i]);
-
-            for(j = 0; j < 3; j++)
-                g3[i][j] = (float)(((rand.nextDouble() * Integer.MAX_VALUE) % (B + B)) - B) / B;
-            normalize3(g3[i]);
-        }
-
-        while(--i > 0)
-        {
-            k = p[i];
-            j = (int)((rand.nextDouble() * Integer.MAX_VALUE) % B);
-            p[i] = p[j];
-            p[j] = k;
-        }
-
-        for(i = 0; i < B + 2; i++)
-        {
-            p[B + i] = p[i];
-            g1[B + i] = g1[i];
-            for(j = 0; j < 2; j++)
-                g2[B + i][j] = g2[i][j];
-            for(j = 0; j < 3; j++)
-                g3[B + i][j] = g3[i][j];
-        }
-    }
 }


### PR DESCRIPTION
Perlin Noise, which is currently being used as the primary base for terrain generation, is an older algorithm that tends to exhibit visually-signficiant directional artifacts. In this day and age where alternatives have been developed, it doesn't make much sense to continue to use Perlin Noise -- especially in a project such as this. This replaces the code inside PerlinNoise.java with code that generates OpenSimplex Noise instead. OpenSimplex Noise is much more visually isotropic (free of visually-significant directional artifacts).
